### PR TITLE
Fix #14: handle upload webhooks

### DIFF
--- a/app/utils/formats.py
+++ b/app/utils/formats.py
@@ -53,12 +53,19 @@ class ANHash(HALEasy):
         items = []
         for d in data:
             for k, v in d.items():
-                if k not in ("osdi:submission", "osdi:donation"):
+                if k not in (
+                    "osdi:submission",
+                    "osdi:donation",
+                    "action_network:upload",
+                ):
                     continue
                 self = cls("https://actionnetwork.org", json_str=json.dumps(v))
                 self.body = v
                 if k == "osdi:donation":
                     self.form_name = "donation"
+                    items.append(self)
+                elif k == "action_network:upload":
+                    self.form_name = "upload"
                     items.append(self)
                 else:
                     if form_url := self.get_link_url("osdi:form"):

--- a/app/workers/webhook_transfer.py
+++ b/app/workers/webhook_transfer.py
@@ -51,6 +51,9 @@ async def process_items(list_key: str) -> Optional[str]:
             if form_name == "donation":
                 print(f"Found donation item.")
                 await transfer_donation(item)
+            elif form_name == "upload":
+                print(f"Found upload item.")
+                await transfer_person(item)
             else:
                 print(f"Found {form_name} submission item.")
                 await transfer_person(item)

--- a/tests/test_an.py
+++ b/tests/test_an.py
@@ -183,13 +183,14 @@ def test_webhook_good_person(server, database):
     test_case = [
         test_cases["valid filled GRU data"],
         test_cases["valid donation sample"],
+        test_cases["valid upload sample"],
     ]
     endpoint = "/action_network/notification"
     response = requests.post(
         host + endpoint, json=test_case, headers={"Accept": "application/json"}
     )
-    time.sleep(5.0)  # give server chance to process webhook task
+    time.sleep(6.0)  # give server chance to process webhook task
     assert response.status_code == 200
-    assert response.json() == {"accepted": 2}
-    assert redis.db.llen(redis.get_key("Successfully processed")) == 2
+    assert response.json() == {"accepted": 3}
+    assert redis.db.llen(redis.get_key("Successfully processed")) == 3
     assert redis.db.llen(redis.get_key("Failed to process")) == 0

--- a/tests/webhooks.json
+++ b/tests/webhooks.json
@@ -252,5 +252,61 @@
       "title": "Everyday People PAC",
       "url": "https://actionnetwork.org/groups/everyday-people-pac"
     }
+  },
+  "valid upload sample":
+  {
+    "action_network:upload": {
+      "created_date": "2018-11-07T19:49:26Z",
+      "modified_date": "2018-11-07T19:49:26Z",
+      "person": {
+        "created_date": "2018-11-07T17:56:40Z",
+        "modified_date": "2018-11-07T19:46:40Z",
+        "family_name": "Smith",
+        "postal_addresses": [
+          {
+            "primary": true,
+            "address_lines": [
+              "1600 Pennsylvania Ave NW"
+            ],
+            "locality": "Washington",
+            "postal_code": "20036",
+            "region": "District of Columbia",
+            "country": "US",
+            "location": {
+              "latitude": 41.2967,
+              "longitude": -73.6698,
+              "accuracy": "Approximate"
+            }
+          }
+        ],
+        "email_addresses": [
+          {
+            "primary": true,
+            "address": "jsmith@mail.com",
+            "status": "subscribed"
+          }
+        ],
+        "languages_spoken": [
+          "en"
+        ],
+        "custom_fields": {
+          "phone_number": "123.456.7890"
+        }
+      },
+      "action_network:referrer_data": {},
+      "add_tags": [
+        "volunteer",
+        "member"
+      ],
+      "_links": {
+        "osdi:person": {
+          "href": "https://actionnetwork.org/api/v2/people/14bee58e-ba50-11e3-a134-12313d1576ca"
+        }
+      }
+    },
+    "action_network:sponsor": {
+      "title": "Everyday People PAC",
+      "url": "https://actionnetwork.org/groups/everyday-people-pac"
+    }
   }
 }


### PR DESCRIPTION
Handle upload webhooks exactly like forms.  Add a test based on the action network sample webhook.