### PR TITLE
Fix #22: race conditions in transfer processing

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn -k uvicorn.workers.UvicornWorker app.services.main:app
+worker: gunicorn -k uvicorn.workers.UvicornWorker app.workers.main:app

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -21,3 +21,4 @@
 #  SOFTWARE.
 
 from .redis_db import RedisDatabase, redis
+from .item_list_store import ItemListStore

--- a/app/db/item_list_store.py
+++ b/app/db/item_list_store.py
@@ -1,0 +1,201 @@
+#  MIT License
+#
+#  Copyright (c) 2020 Daniel C. Brotsky
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+import asyncio
+from random import uniform
+from time import time as now
+from typing import ClassVar, Optional, Any
+
+from aioredis import Redis
+
+from .redis_db import redis
+
+
+class ItemListStore:
+    """
+    Item lists are stored in a sorted set in Redis,
+    with the sort key being the time the item can
+    next be processed.
+
+    When an item is actually
+    being processed, the item time is reset to a
+    special marker time encoding the time its
+    processing is expected to complete.  This
+    allows discovering items that were left
+    over from crashes in prior runs.
+
+    This class is a singleton.
+    """
+
+    IN_PROCESS: ClassVar[float] = 1.0 * 60 * 60 * 24 * 7
+    """
+    Item lists that are going to be processed have their score set to
+    a week from now, so they are way further out than delayed items.
+    """
+
+    TIMEOUT: ClassVar[float] = 1.0 * 60 * 20
+    """
+    If an item list has been in processing for 20 minutes, it's believed
+    to have been left over from a prior run.
+    """
+
+    RETRY_DELAY: ClassVar[float] = 1.0 * 60 * 15
+    """
+    Retries of failed item lists are delayed 15 minutes to let
+    the upstream systems recover from whatever their issue was. 
+    """
+
+    CLOCK_DRIFT: ClassVar[float] = 1.0 * 15
+    """
+    There are multiple participating clients of the Store and
+    we allow their clocks to drift by 15 seconds relative to
+    ours whenever we check the time on an item.
+    """
+
+    set_key: ClassVar[str] = redis.get_key("Item List Store")
+    """
+    The sorted set of items with their next-ready times.
+    """
+
+    new_item_channel_name: ClassVar[str] = redis.get_key("Item Arrival")
+
+    db: Optional[Redis]
+
+    @classmethod
+    async def initialize(cls):
+        """
+        Make sure redis is connected and remember the connection pool.
+        """
+        await redis.connect_async()
+        cls.db = redis.db
+
+    @classmethod
+    async def terminate(cls):
+        """
+        Make sure redis is closed.
+        """
+        cls.db = None
+        await redis.close_async()
+
+    @classmethod
+    async def add_new_list(cls, key: str) -> Any:
+        result = await cls.db.zadd(cls.set_key, score=now(), member=key)
+        cls.db.publish(cls.new_item_channel_name, key)
+        return result
+
+    @classmethod
+    async def add_retry_list(cls, key: str) -> Any:
+        result = await cls.db.zadd(
+            cls.set_key, score=now() + cls.RETRY_DELAY, member=key
+        )
+        return result
+
+    @classmethod
+    async def remove_item_list(cls, key: str) -> Any:
+        result = await cls.db.zrem(cls.set_key, key)
+        return result
+
+    @classmethod
+    async def select_new_item(cls) -> Optional[str]:
+        """
+        Wait until there's a new item, then return it.
+        """
+        try:
+            channels = await cls.db.subscribe(cls.new_item_channel_name)
+            key = await channels[0].get(encoding="utf-8")
+            await cls.db.unsubscribe(cls.new_item_channel_name)
+            return key
+        except asyncio.CancelledError:
+            return None
+
+    @classmethod
+    async def select_for_processing(cls, timeout: float = 0) -> Optional[str]:
+        """
+        Find the first item list that's ready for processing,
+        mark it as in-process, and return it.  The select
+        prioritizes any older item lists that were left from a prior run
+        over item lists that haven't been processed before.
+        If there is an item list that's not yet ready for processing,
+        we will wait an optional `timeout` seconds for it to become ready
+        unless (default timeout of 0, which means indefinitely).
+
+        Returns:
+            The item list key, if we selected one, None otherwise.
+        """
+
+        async def mark_for_processing(key: str) -> str:
+            """
+            Mark an item list key as being in process.  Returns the key.
+            """
+            new_score = now() + cls.IN_PROCESS
+            pipe: Redis = cls.db.multi_exec()
+            pipe.zadd(cls.set_key, score=new_score, member=key)
+            await pipe.execute()
+            return key
+
+        # because we are using optimistic locking, keep trying if we
+        # fail due to interference from other workers.
+        while True:
+            try:
+                start = now()
+                # optimistically lock the item set
+                await cls.db.watch(cls.set_key)
+                # first look for abandoned items
+                items = await cls.db.zrangebyscore(
+                    cls.set_key,
+                    min=start + (cls.RETRY_DELAY + cls.CLOCK_DRIFT),
+                    max=start + cls.IN_PROCESS - (cls.TIMEOUT + cls.CLOCK_DRIFT),
+                    offset=0,
+                    count=1,
+                    encoding="ascii",
+                )
+                if items:
+                    return await mark_for_processing(items[0])
+                # next look for the first item that's ready now
+                items = await cls.db.zrangebyscore(
+                    cls.set_key,
+                    max=start + cls.CLOCK_DRIFT,
+                    offset=0,
+                    count=1,
+                    encoding="ascii",
+                )
+                if items:
+                    return await mark_for_processing(items[0])
+                # next look for the first delayed item and maybe wait for it
+                items_and_scores = await cls.db.zrange(
+                    cls.set_key, start=0, stop=0, withscores=True, encoding="ascii"
+                )
+                if items_and_scores:
+                    item, when = items_and_scores[0]
+                    delay = when - start
+                    if 0 < timeout < delay:
+                        # we can't wait for this item to be ready
+                        return None
+                    # wait for this item, then try again
+                    # we add a random delay to avoid conflict with other processors
+                    await asyncio.sleep(delay + uniform(0.1, cls.CLOCK_DRIFT))
+                    continue
+                # give up
+                return None
+            except redis.WatchError:
+                continue
+            finally:
+                await cls.db.unwatch()

--- a/app/db/redis_db.py
+++ b/app/db/redis_db.py
@@ -56,8 +56,12 @@ class RedisDatabase:
         self.db = await create_redis_pool(self.url, maxsize=max_connections)
 
     async def close_async(self):
+        if self.db is None:
+            return
+
         self.db.close()
         await self.db.wait_closed()
+        self.db = None
 
     def connect_sync(self):
         if self.db is not None:
@@ -70,7 +74,11 @@ class RedisDatabase:
         self.db = from_url(self.url, max_connections=max_connections)
 
     def close_sync(self):
+        if self.db is None:
+            return
+
         self.db.close()
+        self.db = None
 
     def get_key(self, name: str) -> str:
         """

--- a/app/db/redis_db.py
+++ b/app/db/redis_db.py
@@ -44,16 +44,14 @@ class RedisDatabase:
         self.db = None
         self.keys = {}
         self.Error = Exception
-        self.WatchError = Exception
 
     async def connect_async(self):
         if self.db is not None:
             return
 
-        from aioredis import RedisError, WatchVariableError, create_redis_pool
+        from aioredis import RedisError, create_redis_pool
 
         self.Error = RedisError
-        self.WatchError = WatchVariableError
         max_connections = 5 if env() is Environment.PROD else 2
         self.db = await create_redis_pool(self.url, maxsize=max_connections)
 
@@ -65,10 +63,9 @@ class RedisDatabase:
         if self.db is not None:
             return
 
-        from redis import RedisError, WatchError, from_url
+        from redis import RedisError, from_url
 
         self.Error = RedisError
-        self.WatchError = WatchError
         max_connections = 5 if env() is Environment.PROD else 2
         self.db = from_url(self.url, max_connections=max_connections)
 

--- a/app/services/an.py
+++ b/app/services/an.py
@@ -66,10 +66,10 @@ def database_error(context: str) -> JSONResponse:
         }
     },
     summary="Receiver for new webhook messages. "
-    "Specify query parameter 'spawn_worker' as 'true' "
-    "to spawn a worker task to process the webhook.",
+    "Specify query parameter 'force_transfer' as 'true' "
+    "to create a explicit task to transfer the webhook.",
 )
-async def receive_notification(body: List[Dict], spawn_worker: bool = False):
+async def receive_notification(body: List[Dict], force_transfer: bool = False):
     """
     Receive a notification from an Action Network web hook.
 
@@ -86,8 +86,8 @@ async def receive_notification(body: List[Dict], spawn_worker: bool = False):
         except redis.Error:
             return database_error(f"while saving received items")
     print(f"Accepted {len(items)} item(s) from webhook.")
-    if spawn_worker and env() != Environment.PROD:
-        print(f"Running worker task to transfer received item(s).")
+    if force_transfer:
+        print(f"Running transfer task over received item(s).")
         asyncio.create_task(process_all_item_lists())
     return WebHookResponse(accepted=len(items))
 

--- a/app/services/an.py
+++ b/app/services/an.py
@@ -28,9 +28,9 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 
-from ..db import redis
-from ..utils import ANHash, log_error, env, seq_id, Environment
-from ..workers import transfer_all_webhook_items
+from ..db import redis, ItemListStore as Store
+from ..utils import ANHash, log_error, env, Timestamp, Environment
+from ..workers import process_all_item_lists
 
 an = APIRouter()
 
@@ -65,31 +65,30 @@ def database_error(context: str) -> JSONResponse:
             "description": "Database error during processing",
         }
     },
-    summary="Receiver for new webhook messages. Valid hooks are "
-    "processed immediately unless query parameter "
-    "'delay_processing' is specified as 'true'",
+    summary="Receiver for new webhook messages. "
+    "Specify query parameter 'spawn_worker' as 'true' "
+    "to spawn a worker task to process the webhook.",
 )
-async def receive_notification(body: List[Dict], delay_processing: bool = False):
+async def receive_notification(body: List[Dict], spawn_worker: bool = False):
     """
     Receive a notification from an Action Network web hook.
 
     See https://actionnetwork.org/docs/webhooks for details.
     """
     print(f"Received webhook with {len(body)} hash(es).")
-    ani_key: str = redis.get_key("Submitted Items")
     items = ANHash.find_items(data=body)
     if items:
         values = [pickle.dumps((item.form_name, item.body)) for item in items]
-        list_key = ":".join((env().name, seq_id(), "0"))
+        list_key = f"{env().name}:{Timestamp()}:0"
         try:
             await redis.db.rpush(list_key, *values)
-            await redis.db.rpush(ani_key, list_key)
+            await Store.add_new_list(list_key)
         except redis.Error:
             return database_error(f"while saving received items")
     print(f"Accepted {len(items)} item(s) from webhook.")
-    if not delay_processing:
+    if spawn_worker and env() != Environment.PROD:
         print(f"Running worker task to transfer received item(s).")
-        asyncio.create_task(transfer_all_webhook_items())
+        asyncio.create_task(process_all_item_lists())
     return WebHookResponse(accepted=len(items))
 
 

--- a/app/services/main.py
+++ b/app/services/main.py
@@ -25,6 +25,7 @@ from fastapi import FastAPI
 from .an import an
 from ..db import ItemListStore
 from ..utils import env, Environment, MapContext
+from ..workers import EmbeddedWorker
 
 if env() in (Environment.DEV, Environment.STAGE):
     app = FastAPI()
@@ -39,8 +40,10 @@ app.include_router(an, prefix="/action_network", tags=["action_network"])
 async def startup():
     MapContext.initialize()
     await ItemListStore.initialize()
+    EmbeddedWorker.start()
 
 
 @app.on_event("shutdown")
 async def shutdown():
+    EmbeddedWorker.stop()
     await ItemListStore.terminate()

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -19,7 +19,7 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
-from .general import log_error, Environment, lookup_env, env, seq_id
+from .general import log_error, Environment, lookup_env, env, Timestamp
 from .constants import MapContext
 from .formats import (
     ANHash,

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -235,7 +235,3 @@ class MapContext:
                 cls.load_config_locally(form_path)
             else:
                 cls.load_config_from_aws()
-
-
-# initialize on load
-MapContext.initialize()

--- a/app/utils/formats.py
+++ b/app/utils/formats.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Any, List, Optional, ClassVar, Tuple
+from typing import Dict, Any, List, Optional, ClassVar
 
 from airtable import Airtable
 from dateutil.parser import parse

--- a/app/workers/__init__.py
+++ b/app/workers/__init__.py
@@ -20,5 +20,5 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 
-from .main import app
+from .main import app, EmbeddedWorker
 from .webhook_transfer import process_all_item_lists

--- a/app/workers/__init__.py
+++ b/app/workers/__init__.py
@@ -21,5 +21,4 @@
 #  SOFTWARE.
 
 from .main import app
-from .webhook_transfer import transfer_all_webhook_items
-from .fetch_people import transfer_people
+from .webhook_transfer import process_all_item_lists

--- a/app/workers/fetch_shifts.py
+++ b/app/workers/fetch_shifts.py
@@ -19,13 +19,10 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
-from typing import Dict, List, Tuple
-
 import csv
+from typing import Dict, Tuple
 
 from ..utils import (
-    env,
-    Environment,
     MapContext as MC,
     ATRecord,
     fetch_all_records,

--- a/app/workers/webhook_transfer.py
+++ b/app/workers/webhook_transfer.py
@@ -116,15 +116,15 @@ async def transfer_person(item: ANHash) -> str:
 
 
 async def process_all_item_lists():
-    print(f"Processing all item lists...")
+    print(f"Processing ready item lists...")
     count, retry_count = 0, 0
     try:
         while list_key := await Store.select_for_processing():
             count += 1
             fail_key = await process_item_list(list_key)
-            await Store.remove_item_list(list_key)
             if fail_key:
                 await Store.add_retry_list(fail_key)
+            await Store.remove_item_list(list_key)
     except redis.Error:
         log_error(f"Database failure")
     except asyncio.CancelledError:

--- a/app/workers/webhook_transfer.py
+++ b/app/workers/webhook_transfer.py
@@ -21,7 +21,7 @@
 #  SOFTWARE.
 import asyncio
 import pickle
-from typing import Optional
+from typing import Optional, Tuple
 
 import aiohttp
 
@@ -115,7 +115,7 @@ async def transfer_person(item: ANHash) -> str:
     return an_record.key
 
 
-async def process_all_item_lists():
+async def process_all_item_lists() -> Tuple[int, int]:
     print(f"Processing ready item lists...")
     count, retry_count = 0, 0
     try:
@@ -133,3 +133,4 @@ async def process_all_item_lists():
         log_error(f"Unexpected failure")
     finally:
         print(f"Processed {count} item list(s); got {retry_count} retry list(s).")
+    return count, retry_count

--- a/poetry.lock
+++ b/poetry.lock
@@ -716,7 +716,7 @@ description = "Ultra fast JSON encoder and decoder for Python"
 name = "ujson"
 optional = false
 python-versions = ">=3.5"
-version = "3.0.0"
+version = "3.1.0"
 
 [[package]]
 category = "main"
@@ -745,7 +745,7 @@ description = "The lightning-fast ASGI server."
 name = "uvicorn"
 optional = false
 python-versions = "*"
-version = "0.11.7"
+version = "0.11.8"
 
 [package.dependencies]
 click = ">=7.0.0,<8.0.0"
@@ -796,12 +796,11 @@ description = "Yet another URL library"
 name = "yarl"
 optional = false
 python-versions = ">=3.5"
-version = "1.5.0"
+version = "1.5.1"
 
 [package.dependencies]
 idna = ">=2.0"
 multidict = ">=4.0"
-typing-extensions = ">=3.7.4"
 
 [metadata]
 content-hash = "7127f0756f2171ee52d1797e134cb64b27365ee18a17b083cd3ef08339a22368"
@@ -1216,23 +1215,23 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 ujson = [
-    {file = "ujson-3.0.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:0959a5b569e192459b492b007e3fd63d8f4b4bcb4f69dcddca850a9b9dfe3e7a"},
-    {file = "ujson-3.0.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:154f778f0b028390067aaedce8399730d4f528a16a1c214fe4eeb9c4e4f51810"},
-    {file = "ujson-3.0.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:019a17e7162f26e264f1645bb41630f7103d178c092ea4bb8f3b16126c3ea210"},
-    {file = "ujson-3.0.0-cp35-cp35m-win_amd64.whl", hash = "sha256:670018d4ab4b0755a7234a9f4791723abcd0506c0eed33b2ed50579c4aff31f2"},
-    {file = "ujson-3.0.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:634c206f4fb3be7e4523768c636d2dd41cb9c7130e2d219ef8305b8fb6f4838e"},
-    {file = "ujson-3.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:3bd791d17a175c1c6566aeaec1755b58e3f021fe9bb62f10f02b656b299199f5"},
-    {file = "ujson-3.0.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0379ffc7484b862a292e924c15ad5f1c5306d4271e2efd162144812afb08ff97"},
-    {file = "ujson-3.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f40bb0d0cb534aad3e24884cf864bda7a71eb5984bd1da61d1711bbfb3be2c38"},
-    {file = "ujson-3.0.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:0f33359908df32033195bfdd59ba2bfb90a23cb280ef9a0ba11e5013a53d7fd9"},
-    {file = "ujson-3.0.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:bea2958c7b5bf4f191f0def751b6f7c8b208edb5f7277e21776329f2ca042385"},
-    {file = "ujson-3.0.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f854702a9aff3a445f4a0b715d240f2a3d84014d8ae8aad05a982c7ffab12525"},
-    {file = "ujson-3.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c04d253fec814657fd9f150ef2333dbd0bc6f46208355aa753a29e0696b7fa7e"},
-    {file = "ujson-3.0.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:a32f2def62b10e8a19084d17d40363c4da1ac5f52d300a9e99d7efb49fe5f34a"},
-    {file = "ujson-3.0.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:9c68557da3e3ad57e0105aceba0cce5f8f7cd07d207c3860e59c0b3044532830"},
-    {file = "ujson-3.0.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0e2352b60c4ac4fc75b723435faf36ef5e7f3bfb988adb4d589b5e0e6e1d90aa"},
-    {file = "ujson-3.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:c841a6450d64c24c64cbcca429bab22cdb6daef5eaddfdfebe798a5e9e5aff4c"},
-    {file = "ujson-3.0.0.tar.gz", hash = "sha256:e0199849d61cc6418f94d52a314c6a27524d65e82174d2a043fb718f73d1520d"},
+    {file = "ujson-3.1.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:585329c16eeb0992308545c7a05eee76c7f1c2042b08317aac64fef1e71e71a9"},
+    {file = "ujson-3.1.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:d40d53aa679994624960b1c40bc451c5d9e3a0779f6a04146b417e220ce8f7d4"},
+    {file = "ujson-3.1.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b794a2ddba049daa1fe0f28c4652b54d0d06580e7d3bcae87b4c000fb242654f"},
+    {file = "ujson-3.1.0-cp35-cp35m-win_amd64.whl", hash = "sha256:0789837e7156e07890f2461ec1d9dc2ea4ef7c76fd36e46955d811485daf83b9"},
+    {file = "ujson-3.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:f6e229fa9b7d8586f894d18a003703fea4620ff8e6d39c11499755ecec5b43fc"},
+    {file = "ujson-3.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:ebe1bc9536b93c697f042b6c39ed602ad7edd5ef139eb167d9c8e36594b24546"},
+    {file = "ujson-3.1.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6a2fac9892996c3a46bd3fd8bbf739f19f85fc7ec9cdc11b014f76267c3ee76d"},
+    {file = "ujson-3.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:083778f4e64f90b4468e73e0baafcde0ab83bff85315d28a5b1287a3f5909e7f"},
+    {file = "ujson-3.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:d3f28f64b33609be20f985baa72d43ccfdf87e50d47ca2791d26b9c2f348a35b"},
+    {file = "ujson-3.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3a049acf176dacbb79ee00b13a78fc2524c35c69400e34aa5f6ff0fc3fdbb1f0"},
+    {file = "ujson-3.1.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c2be0d511e5dc302f190e510544c4d5fbbb4396632abe33b66e28dad26ea4325"},
+    {file = "ujson-3.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7e7cdd8a42428cd2716cfe0a506e57168c6a02b8032478209cb4a8a12b8c2c4e"},
+    {file = "ujson-3.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:a8194b778adf38ad679c62e2bb6cf71972ae91102e611e4bb31f625be6fb366a"},
+    {file = "ujson-3.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0184ed23618ce3d793aaf9f5b3dd456cf719b930d3936fb39000589ed0bd2811"},
+    {file = "ujson-3.1.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8032ca897cfce113cb9ca7f07ff4c750afe18c605eeed2e09cf9b882c99fc76b"},
+    {file = "ujson-3.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:bf30ac68d8b2aed665589cfd3608e43d8cd6cb74cd5a9379ab9af9861c33a8be"},
+    {file = "ujson-3.1.0.tar.gz", hash = "sha256:00bda1de275ed6fe81817902189c75dfd156b4fa29b44dc1f4620775d2f50cf7"},
 ]
 uritemplate = [
     {file = "uritemplate-3.0.1-py2.py3-none-any.whl", hash = "sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f"},
@@ -1243,8 +1242,8 @@ urllib3 = [
     {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 uvicorn = [
-    {file = "uvicorn-0.11.7-py3-none-any.whl", hash = "sha256:1d46a22cc55a52f5567e0c66f000ae56f26263e44cef59b7c885bf10f487ce6e"},
-    {file = "uvicorn-0.11.7.tar.gz", hash = "sha256:b50f7f4c0c499c9b8d0280924cfbd24b90ba02456e3dc80934b9a786a291f09f"},
+    {file = "uvicorn-0.11.8-py3-none-any.whl", hash = "sha256:4b70ddb4c1946e39db9f3082d53e323dfd50634b95fd83625d778729ef1730ef"},
+    {file = "uvicorn-0.11.8.tar.gz", hash = "sha256:46a83e371f37ea7ff29577d00015f02c942410288fb57def6440f2653fff1d26"},
 ]
 uvloop = [
     {file = "uvloop-0.14.0-cp35-cp35m-macosx_10_11_x86_64.whl", hash = "sha256:08b109f0213af392150e2fe6f81d33261bb5ce968a288eb698aad4f46eb711bd"},
@@ -1289,21 +1288,21 @@ wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]
 yarl = [
-    {file = "yarl-1.5.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:2657716c1fc998f5f2675c0ee6ce91282e0da0ea9e4a94b584bb1917e11c1559"},
-    {file = "yarl-1.5.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:cf5eb664910d759bbae0b76d060d6e21f8af5098242d66c448bbebaf2a7bfa70"},
-    {file = "yarl-1.5.0-cp35-cp35m-win32.whl", hash = "sha256:875b2a741ce0208f3b818008a859ab5d0f461e98a32bbdc6af82231a9e761c55"},
-    {file = "yarl-1.5.0-cp35-cp35m-win_amd64.whl", hash = "sha256:1707230e1ea48ea06a3e20acb4ce05a38d2465bd9566c21f48f6212a88e47536"},
-    {file = "yarl-1.5.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:9a592c4aa642249e9bdaf76897d90feeb08118626b363a6be8788a9b300274b5"},
-    {file = "yarl-1.5.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:f058b6541477022c7b54db37229f87dacf3b565de4f901ff5a0a78556a174fea"},
-    {file = "yarl-1.5.0-cp36-cp36m-win32.whl", hash = "sha256:5d410f69b4f92c5e1e2a8ffb73337cd8a274388c6975091735795588a538e605"},
-    {file = "yarl-1.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5bbcb195da7de57f4508b7508c33f7593e9516e27732d08b9aad8586c7b8c384"},
-    {file = "yarl-1.5.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:a1772068401d425e803999dada29a6babf041786e08be5e79ef63c9ecc4c9575"},
-    {file = "yarl-1.5.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1f269e8e6676193a94635399a77c9059e1826fb6265c9204c9e5a8ccd36006e1"},
-    {file = "yarl-1.5.0-cp37-cp37m-win32.whl", hash = "sha256:431faa6858f0ea323714d8b7b4a7da1db2eeb9403607f0eaa3800ab2c5a4b627"},
-    {file = "yarl-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b325fefd574ebef50e391a1072d1712a60348ca29c183e1d546c9d87fec2cd32"},
-    {file = "yarl-1.5.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:b065a5c3e050395ae563019253cc6c769a50fd82d7fa92d07476273521d56b7c"},
-    {file = "yarl-1.5.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:66b4f345e9573e004b1af184bc00431145cf5e089a4dcc1351505c1f5750192c"},
-    {file = "yarl-1.5.0-cp38-cp38-win32.whl", hash = "sha256:9a3266b047d15e78bba38c8455bf68b391c040231ca5965ef867f7cbbc60bde5"},
-    {file = "yarl-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:f5cfed0766837303f688196aa7002730d62c5cc802d98c6395ea1feb87252727"},
-    {file = "yarl-1.5.0.tar.gz", hash = "sha256:5c82f5b1499342339f22c83b97dbe2b8a09e47163fab86cd934a8dd46620e0fb"},
+    {file = "yarl-1.5.1-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:db6db0f45d2c63ddb1a9d18d1b9b22f308e52c83638c26b422d520a815c4b3fb"},
+    {file = "yarl-1.5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:17668ec6722b1b7a3a05cc0167659f6c95b436d25a36c2d52db0eca7d3f72593"},
+    {file = "yarl-1.5.1-cp35-cp35m-win32.whl", hash = "sha256:040b237f58ff7d800e6e0fd89c8439b841f777dd99b4a9cca04d6935564b9409"},
+    {file = "yarl-1.5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:f18d68f2be6bf0e89f1521af2b1bb46e66ab0018faafa81d70f358153170a317"},
+    {file = "yarl-1.5.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:c52ce2883dc193824989a9b97a76ca86ecd1fa7955b14f87bf367a61b6232511"},
+    {file = "yarl-1.5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ce584af5de8830d8701b8979b18fcf450cef9a382b1a3c8ef189bedc408faf1e"},
+    {file = "yarl-1.5.1-cp36-cp36m-win32.whl", hash = "sha256:df89642981b94e7db5596818499c4b2219028f2a528c9c37cc1de45bf2fd3a3f"},
+    {file = "yarl-1.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:3a584b28086bc93c888a6c2aa5c92ed1ae20932f078c46509a66dce9ea5533f2"},
+    {file = "yarl-1.5.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:da456eeec17fa8aa4594d9a9f27c0b1060b6a75f2419fe0c00609587b2695f4a"},
+    {file = "yarl-1.5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bc2f976c0e918659f723401c4f834deb8a8e7798a71be4382e024bcc3f7e23a8"},
+    {file = "yarl-1.5.1-cp37-cp37m-win32.whl", hash = "sha256:4439be27e4eee76c7632c2427ca5e73703151b22cae23e64adb243a9c2f565d8"},
+    {file = "yarl-1.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:48e918b05850fffb070a496d2b5f97fc31d15d94ca33d3d08a4f86e26d4e7c5d"},
+    {file = "yarl-1.5.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9b930776c0ae0c691776f4d2891ebc5362af86f152dd0da463a6614074cb1b02"},
+    {file = "yarl-1.5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b3b9ad80f8b68519cc3372a6ca85ae02cc5a8807723ac366b53c0f089db19e4a"},
+    {file = "yarl-1.5.1-cp38-cp38-win32.whl", hash = "sha256:f379b7f83f23fe12823085cd6b906edc49df969eb99757f58ff382349a3303c6"},
+    {file = "yarl-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:9102b59e8337f9874638fcfc9ac3734a0cfadb100e47d55c20d0dc6087fb4692"},
+    {file = "yarl-1.5.1.tar.gz", hash = "sha256:c22c75b5f394f3d47105045ea551e08a3e804dc7e01b37800ca35b58f856c3d6"},
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,11 +46,11 @@ s3transfer==0.3.3
 six==1.15.0
 starlette==0.13.6
 typing-extensions==3.7.4.2
-ujson==3.0.0
+ujson==3.1.0
 uritemplate==3.0.1
 urllib3==1.25.10
-uvicorn==0.11.7
+uvicorn==0.11.8
 uvloop==0.14.0; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy"
 websockets==8.1
 wrapt==1.12.1
-yarl==1.5.0
+yarl==1.5.1

--- a/tests/test_an.py
+++ b/tests/test_an.py
@@ -20,17 +20,13 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 import json
-import os
 import time
-from multiprocessing import Process, set_start_method
 
 import pytest
 import requests
-import uvicorn
 
-from app.utils import env, Environment
-from app.services.main import app
 from app.db import redis_db
+from app.utils import env, Environment
 
 
 @pytest.fixture(scope="session")
@@ -139,7 +135,7 @@ def test_webhook_bad_person_noprocess_retrieve_process_retrieve(server, database
     test_case = test_cases["incorrect person id"]
     endpoint_p = "/action_network/notification"
     _ = requests.post(
-        host + endpoint_p + "?delay_processing=true",
+        host + endpoint_p + "?spawn_worker=true",
         json=[test_case],
         headers={"Accept": "application/json"},
     )
@@ -157,7 +153,7 @@ def test_webhook_bad_person_noprocess_retrieve_process_retrieve(server, database
     for k, v in body.items():
         assert sub_data[k] == v
     _ = requests.post(
-        host + endpoint_p + "?delay_processing=false",
+        host + endpoint_p + "?spawn_worker=false",
         json=[test_case],
         headers={"Accept": "application/json"},
     )

--- a/tests/test_an.py
+++ b/tests/test_an.py
@@ -135,7 +135,7 @@ def test_webhook_bad_person_noprocess_retrieve_process_retrieve(server, database
     test_case = test_cases["incorrect person id"]
     endpoint_p = "/action_network/notification"
     _ = requests.post(
-        host + endpoint_p + "?spawn_worker=true",
+        host + endpoint_p + "?force_transfer=true",
         json=[test_case],
         headers={"Accept": "application/json"},
     )
@@ -153,7 +153,7 @@ def test_webhook_bad_person_noprocess_retrieve_process_retrieve(server, database
     for k, v in body.items():
         assert sub_data[k] == v
     _ = requests.post(
-        host + endpoint_p + "?spawn_worker=false",
+        host + endpoint_p + "?force_transfer=false",
         json=[test_case],
         headers={"Accept": "application/json"},
     )

--- a/transfer_donations.py
+++ b/transfer_donations.py
@@ -19,7 +19,9 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
+from app.utils import MapContext
 from app.workers.fetch_donations import transfer_all_donations
 
 if __name__ == "__main__":
+    MapContext.initialize()
     transfer_all_donations()

--- a/transfer_people.py
+++ b/transfer_people.py
@@ -21,9 +21,11 @@
 #  SOFTWARE.
 import sys
 
+from app.utils import MapContext
 from app.workers.fetch_people import transfer_people
 
 if __name__ == "__main__":
+    MapContext.initialize()
     if len(sys.argv) > 1:
         transfer_people(sys.argv[1:])
     else:

--- a/transfer_shifts.py
+++ b/transfer_shifts.py
@@ -21,9 +21,11 @@
 #  SOFTWARE.
 import sys
 
+from app.utils import MapContext
 from app.workers.fetch_shifts import transfer_shifts
 
 if __name__ == "__main__":
+    MapContext.initialize()
     if len(sys.argv) == 2:
         transfer_shifts(sys.argv[1])
     else:

--- a/web_runner.py
+++ b/web_runner.py
@@ -44,7 +44,6 @@
 import uvicorn
 
 from app.services.main import app
-from app.utils import env, Environment
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="localhost", port=8080, debug=env() != Environment.PROD)
+    uvicorn.run(app, host="localhost", port=8080)

--- a/web_runner.py
+++ b/web_runner.py
@@ -44,6 +44,7 @@
 import uvicorn
 
 from app.services.main import app
+from app.utils import env, Environment
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="localhost", port=8080)
+    uvicorn.run(app, host="localhost", port=8080, debug=env() != Environment.PROD)

--- a/worker_runner.py
+++ b/worker_runner.py
@@ -21,11 +21,10 @@
 #  SOFTWARE.
 import asyncio
 
-from app.utils import env, Environment
 from app.workers.main import app
 
 if __name__ == "__main__":
     try:
-        asyncio.run(app(), debug=env() != Environment.PROD)
+        asyncio.run(app())
     except KeyboardInterrupt:
         pass

--- a/worker_runner.py
+++ b/worker_runner.py
@@ -19,31 +19,12 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
-
-#  MIT License
-#
-#
-#  Permission is hereby granted, free of charge, to any person obtaining a copy
-#  of this software and associated documentation files (the "Software"), to deal
-#  in the Software without restriction, including without limitation the rights
-#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-#  copies of the Software, and to permit persons to whom the Software is
-#  furnished to do so, subject to the following conditions:
-#
-#  The above copyright notice and this permission notice shall be included in all
-#  copies or substantial portions of the Software.
-#
-#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-#  SOFTWARE.
-
 import asyncio
 
 from app.workers.main import app
 
 if __name__ == "__main__":
-    asyncio.run(app())
+    try:
+        asyncio.run(app())
+    except KeyboardInterrupt:
+        pass

--- a/worker_runner.py
+++ b/worker_runner.py
@@ -21,10 +21,11 @@
 #  SOFTWARE.
 import asyncio
 
+from app.utils import env, Environment
 from app.workers.main import app
 
 if __name__ == "__main__":
     try:
-        asyncio.run(app())
+        asyncio.run(app(), debug=env() != Environment.PROD)
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
The original approach of queueing item lists was quite weak about concurrent workers running, which would often happen when multiple web hooks arrived close together.  The fix is to have workers which wake up when new items arrive, or when a failed item list is ready to retry.  So now we keep a set of item lists sorted by when they are ready to be processed.  And we keep the in-process lists at the end of the list, so if we crash we see them and pick them up at the start of the next run.