### PR TITLE
Hotfix: allow embedded workers on PROD

### DIFF
--- a/app/workers/main.py
+++ b/app/workers/main.py
@@ -117,9 +117,8 @@ class EmbeddedWorker:
 
     @classmethod
     def start(cls):
-        if env() != Environment.PROD:
-            if os.getenv("EMBEDDED_WORKER") is not None:
-                cls.worker_task = asyncio.create_task(cls.app())
+        if os.getenv("EMBEDDED_WORKER") is not None:
+            cls.worker_task = asyncio.create_task(cls.app())
 
     @classmethod
     def stop(cls):


### PR DESCRIPTION
Something seems to be wrong with gunicorn workers on PROD.  Trying to use an embedded worker for now.