### PR TITLE
Fix #32: get workers running on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn -k uvicorn.workers.UvicornWorker app.services.main:app
-worker: gunicorn -k uvicorn.workers.UvicornWorker app.workers.main:app
+worker: python worker_runner.py


### PR DESCRIPTION
This was a really stupid mistake.  You can't use an ASGI manager on a non-web worker.  Sigh.