### PR TITLE
Fix #55: delay and retry shifts whose event is not yet uploaded

### DIFF
--- a/app/db/item_list_store.py
+++ b/app/db/item_list_store.py
@@ -52,15 +52,15 @@ class ItemListStore:
     a week from now, so they are way further out than delayed items.
     """
 
-    TIMEOUT: ClassVar[float] = 1.0 * 60 * 20
+    TIMEOUT: ClassVar[float] = 1.0 * 60 * 60 * 6
     """
-    If an item list has been in processing for 20 minutes, it's believed
+    If an item list has been in processing for six hours, it's believed
     to have been left over from a prior run.
     """
 
-    RETRY_DELAY: ClassVar[float] = 1.0 * 60 * 15
+    RETRY_DELAY: ClassVar[float] = 1.0 * 60 * 30
     """
-    Retries of failed item lists are delayed 15 minutes to let
+    Retries of failed item lists are delayed 30 minutes to let
     the upstream systems recover from whatever their issue was. 
     """
 

--- a/app/utils/formats.py
+++ b/app/utils/formats.py
@@ -268,10 +268,10 @@ class ATRecord:
         if event_id := data.get("event id"):
             if timeslot_id := data.get("timeslot id"):
                 shift_id = f"User {email} at Event {event_id}-{timeslot_id}"
-                event_link = [f"Event {event_id}-{timeslot_id}"]
+                event_id = f"Event {event_id}-{timeslot_id}"
             else:
                 shift_id = f"User {email} at Event {event_id}"
-                event_link = [f"Event {event_id}"]
+                event_id = f"Event {event_id}"
         else:
             prinl(f"Shift data has no 'event id' field, skipping it: {data}")
             return None
@@ -283,7 +283,7 @@ class ATRecord:
         core_fields: Dict[str, str] = {
             "shift id": shift_id,
             "Timestamp (EST)": est_time_str,
-            "event": event_link,
+            "event": event_id,
         }
         custom_fields: Dict[str, Any] = {}
         for name, value in data.items():


### PR DESCRIPTION
While I was in there, I tweaked a few things:

- increased the timeout for processing an item list to 6 hours, based on our experience with large bulk imports when the cache is empty.
- altered logging so that detailed logging of an error happens right with the error and not just when the exception is handled.  This keeps the detailed logging in the same time as the item processing.  For some reason exceptions are logged much later; perhaps they are being handled on a different thread.