### PR TITLE
Fix #57: Action Network phone numbers not being transferred.

### DIFF
--- a/app/utils/records.py
+++ b/app/utils/records.py
@@ -129,7 +129,9 @@ def fetch_all_records() -> Dict[str, ATRecord]:
 
 
 def compare_record_maps(
-    at_map: Dict[str, ATRecord], an_map: Dict[str, ATRecord]
+    at_map: Dict[str, ATRecord],
+    an_map: Dict[str, ATRecord],
+    assume_newer: bool = False,
 ) -> Dict[str, Dict]:
     prinl(
         f"Comparing {len(at_map)} Airtable record(s) "
@@ -141,7 +143,7 @@ def compare_record_maps(
         if an_v:
             del an_only[at_k]
             an_v.at_match = at_v  # remember airbase match
-            if an_v.mod_date > at_v.mod_date:
+            if assume_newer or an_v.mod_date > at_v.mod_date:
                 an_newer[at_k] = an_v
             else:
                 matching[at_k] = an_v
@@ -163,7 +165,9 @@ def compare_record_maps(
     return result
 
 
-def make_record_updates(comparison_map: Dict[str, Dict[str, ATRecord]]):
+def make_record_updates(
+    comparison_map: Dict[str, Dict[str, ATRecord]], assume_newer: bool = False
+):
     """Update Airtable from newer Action Network records"""
     record_type = MC.get()
     at_key, at_base, at_table, at_typecast = MC.at_connect_info()
@@ -180,7 +184,7 @@ def make_record_updates(comparison_map: Dict[str, Dict[str, ATRecord]]):
     if an_newer:
         update_map: Dict[str, Dict[str, Any]] = {}
         for key, record in an_newer.items():
-            updates = record.find_at_field_updates()
+            updates = record.find_at_field_updates(assume_newer=assume_newer)
             if updates:
                 update_map[record.at_match.record_id] = updates
         if update_map:

--- a/app/workers/fetch_donations.py
+++ b/app/workers/fetch_donations.py
@@ -23,10 +23,8 @@ from typing import Dict, List, Tuple, Set
 
 import requests
 
+from ..base import prinl, Environment, env
 from ..utils import (
-    prinl,
-    env,
-    Environment,
     MapContext as MC,
     ATRecord,
     ANHash,

--- a/app/workers/fetch_people.py
+++ b/app/workers/fetch_people.py
@@ -23,10 +23,8 @@ from typing import Dict, List, Set, Sequence
 
 import requests
 
+from ..base import prinl, Environment, env
 from ..utils import (
-    prinl,
-    Environment,
-    env,
     MapContext as MC,
     ATRecord,
     ANHash,
@@ -136,7 +134,7 @@ def fetch_people(people_urls: Sequence[str]) -> Dict[str, ATRecord]:
     return people
 
 
-def transfer_people(form_names: List[str] = None):
+def transfer_people(form_names: List[str], assume_newer=False):
     prinl(f"Transferring people...")
     MC.set("person")
     record_map = fetch_all_records()
@@ -147,6 +145,6 @@ def transfer_people(form_names: List[str] = None):
     else:
         urls = fetch_all_people_urls()
     people_map = fetch_people(urls)
-    comparison_map = compare_record_maps(record_map, people_map)
-    make_record_updates(comparison_map)
+    comparison_map = compare_record_maps(record_map, people_map, assume_newer)
+    make_record_updates(comparison_map, assume_newer)
     prinl(f"Finished transferring people.")

--- a/transfer_people.py
+++ b/transfer_people.py
@@ -26,7 +26,10 @@ from app.workers.fetch_people import transfer_people
 
 if __name__ == "__main__":
     MapContext.initialize()
-    if len(sys.argv) > 1:
-        transfer_people(sys.argv[1:])
-    else:
-        transfer_people()
+    assume_newer = False
+    args = sys.argv[1:]
+    if "--add-fields" in args:
+        assume_newer = True
+        args.remove("--add-fields")
+        assume_newer = True
+    transfer_people(args, assume_newer)


### PR DESCRIPTION
Now they are, along with the mobile opt-out field.

This transformation adds new fields, so it requires an entire re-import of all the existing people.  The current compare-and-update code wouldn't do that because the mod dates hadn't changed, so I added an argument to pass into that code to override the mod date and force the transfer.