### PR TITLE
Fix #59: Delete Airtable records for shifts and event deleted from Mobilize

### DIFF
--- a/app/db/record_cache.py
+++ b/app/db/record_cache.py
@@ -21,7 +21,7 @@
 #  SOFTWARE.
 import pickle
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 from aioredis import Redis
 
@@ -30,21 +30,31 @@ from .redis_db import redis
 
 class RecordCache:
     """
-    We keep a Redis-based cache of records that we often need
-    to look up.  We map from the key by which we look up the
-    records to the last mod date of the record, and clients use
-    the mod date to decide if the cache can be used.
+    We keep a Redis-based cache of records in Airtable.
 
-    Note that this cache is to establish the existence of a
+    This cache is to establish the existence (or not) of a
     record in Airtable, not to read its content.  If you need
     its content, then you need to fetch the record.
+
+    For each record type,
+    we keep the set of keys that we have looked up
+    for that type of record.
+
+    For each record in the cache,
+    we keep the last mod date and record ID of the record
+    (or None if the record is cached as missing).
 
     This class is a singleton.
     """
 
-    KEY_FORMAT = "RecordCache|||{record_type}|||{key}"
+    TYPE_FORMAT = "RecordCache|{record_type}|"
     """
-    Each cache key has this format.
+    Each record type has this format for the key of its set of record keys.
+    """
+
+    KEY_FORMAT = "RecordCache|{record_type}|{key}|"
+    """
+    Each record has this format for its cache key.
     """
 
     db: Optional[Redis]
@@ -66,39 +76,65 @@ class RecordCache:
         cls.db = None
 
     @classmethod
-    async def add_record(cls, record_type: str, key: str, mod_date: datetime):
-        """Add a record to the cache."""
+    async def _get_key(cls, record_type: str, key: str) -> str:
         key_name = cls.KEY_FORMAT.format(record_type=record_type, key=key)
-        cache_key = redis.get_key(key_name)
-        value = pickle.dumps(mod_date)
-        await cls.db.set(cache_key, value)
+        record_key = redis.get_key(key_name)
+        return record_key
+
+    @classmethod
+    async def _add_key(cls, record_type: str, key: str) -> str:
+        type_name = cls.TYPE_FORMAT.format(record_type=record_type)
+        type_key = redis.get_key(type_name)
+        await cls.db.sadd(type_key, key)
+        return await cls._get_key(record_type, key)
+
+    @classmethod
+    async def add_record(
+        cls, record_type: str, key: str, mod_date: datetime, record_id: str
+    ):
+        """Add a record to the cache."""
+        record_key = await cls._add_key(record_type, key)
+        value = pickle.dumps((mod_date, record_id))
+        await cls.db.set(record_key, value)
 
     @classmethod
     async def mark_missing(cls, record_type: str, key: str):
-        """Mark a record as affirmatively not in the cache"""
-        key_name = cls.KEY_FORMAT.format(record_type=record_type, key=key)
-        cache_key = redis.get_key(key_name)
+        """Mark a record as affirmatively not in Airtable"""
+        record_key = await cls._add_key(record_type, key)
         value = pickle.dumps(None)
-        await cls.db.set(cache_key, value)
+        await cls.db.set(record_key, value)
 
     @classmethod
     async def get_record(
         cls, record_type: str, key: str
-    ) -> Tuple[bool, Optional[datetime]]:
+    ) -> Tuple[bool, Optional[Tuple[datetime, str]]]:
         """
-        Look up a record in the cache.  The first value returned
+        Look up a record in the cache.
+
+        The first value returned
         indicates whether there was a value in the cache.
         If that's True, then the second value is
         either None, which means that the
         record doesn't exist in the Airtable side,
-        or it's the mod_date of the existing Airtable record.
+        or it's a tuple of the mod_date and key of the Airtable record.
         """
         if not key:
             return False, None
-        key_name = cls.KEY_FORMAT.format(record_type=record_type, key=key)
-        cache_key = redis.get_key(key_name)
-        value = await cls.db.get(cache_key)
+        key = await cls._get_key(record_type, key)
+        value = await cls.db.get(key)
         if not value:
             return False, None
         value = pickle.loads(value)
         return True, value
+
+    @classmethod
+    async def get_all_records(cls, record_type: str) -> List[Tuple[str, datetime, str]]:
+        type_name = cls.TYPE_FORMAT.format(record_type=record_type)
+        type_key = redis.get_key(type_name)
+        result: List[Tuple[str, datetime, str]] = []
+        for key in await cls.db.smembers(type_key, encoding="utf-8"):
+            record_key = await cls._get_key(record_type, key)
+            value = pickle.loads(await cls.db.get(record_key))
+            if value:
+                result.append((key, value[0], value[1]))
+        return result

--- a/app/services/mobilize.py
+++ b/app/services/mobilize.py
@@ -164,7 +164,7 @@ async def transfer_shift_csv(
 async def process_csv_rows(
     kind: str, headings: List, data: List[List], force_transfer: bool
 ) -> int:
-    list_key = f"{env().name}:{Timestamp()}:0"
+    list_key = f"{env().name}:{kind}:{Timestamp()}:0"
     items = [pickle.dumps((kind, dict(zip(headings, row)))) for row in data]
     try:
         await redis.db.rpush(list_key, *items)

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -22,6 +22,7 @@
 from .constants import MapContext
 from .formats import ANHash, ATRecord
 from .records import (
+    RecordBatch,
     lookup_record,
     insert_or_update_record,
     fetch_all_records,

--- a/app/workers/load_cache.py
+++ b/app/workers/load_cache.py
@@ -38,7 +38,8 @@ async def load_cache(record_types: List[str]):
         prinl(f"Adding {total} {record_type} records to cache...")
         batch = RecordBatch(record_type) if record_type in ["event", "shift"] else None
         for count, record in enumerate(record_map.values()):
-            await batch.add_record(record.key)
+            if batch:
+                await batch.add_record(record.key)
             await RecordCache.add_record(
                 record_type, record.key, record.mod_date, record.record_id
             )


### PR DESCRIPTION
Requires reworking the cache and doing extra processing on each shift or event upload.