### PR TITLE
Fix #59 again: delete events from Airtable when deleted from Mobilize.

### DIFF
--- a/app/utils/formats.py
+++ b/app/utils/formats.py
@@ -276,7 +276,7 @@ class ATRecord:
         return cls._from_fields(key="row_id", core=core, custom=custom)
 
     @classmethod
-    def from_mobilize_shift(cls, data: Dict[str, str]) -> Optional[ATRecord]:
+    def from_mobilize_shift(cls, data: Dict[str, str]) -> ATRecord:
         email = data["email"]
         if event_id := data.get("event id"):
             if timeslot_id := data.get("timeslot id"):
@@ -286,7 +286,8 @@ class ATRecord:
                 shift_id = f"User {email} at Event {event_id}"
                 event_id = f"Event {event_id}"
         else:
-            return None
+            shift_id = f"User {email} at Unknown event"
+            event_id = "<Unknown event>"
         for key in ["attended", "rating", "Spanish", "status"]:
             if not data.get(key):
                 data.pop(key, None)

--- a/app/workers/csv_transfer.py
+++ b/app/workers/csv_transfer.py
@@ -79,7 +79,7 @@ def transfer_events(headings, rows):
             event_record.core_fields["email"] = ""
         events[event_record.key] = event_record
     event_map = compare_record_maps(airtable_events, events)
-    make_record_updates(event_map)
+    make_record_updates(event_map, delete_unmatched=True)
 
 
 def transfer_shifts(headings, rows):
@@ -96,13 +96,9 @@ def transfer_shifts(headings, rows):
         row_data = dict(zip(headings, row))
         MC.set("shift")
         shift_record = ATRecord.from_mobilize_shift(row_data)
-        if not shift_record:
-            prinl(f"No event id: skipping shift on row {i+2}.")
-            continue
         event_id = shift_record.core_fields["event"]
         if airtable_events.get(event_id) is None:
-            prinl(f"{event_id} not found: skipping shift on row {i+2}.")
-            continue
+            shift_record.core_fields["event"] = ""
         else:
             shift_record.core_fields["event"] = [event_id]
         shifts[shift_record.key] = shift_record


### PR DESCRIPTION
Also made a change to retain all shifts even if they have no current event IDs, since we want the historical data.

Also updated an incorrect attribution string in the logs.