### PR TITLE
Fix #74: add security to CSV uploads

### DIFF
--- a/docs/upload_csv.html
+++ b/docs/upload_csv.html
@@ -14,6 +14,7 @@
           action="/mobilize/transfer-event-csv"
           enctype="multipart/form-data">
         <input type="file" id="event_upload" name="file" style="width: 25em;">
+        <input type="password" id="event_password" name="password" size="10" />
         <button type="submit">Upload</button>
     </form>
     <h2>Shifts Upload</h2>
@@ -27,6 +28,7 @@
           action="/mobilize/transfer-shift-csv"
           enctype="multipart/form-data">
         <input type="file" id="shift_upload" name="file" style="width: 25em;">
+        <input type="password" id="shift_password" name="password" size="10" />
         <button type="submit">Upload</button>
     </form>
 </body>

--- a/templates/upload_error.html
+++ b/templates/upload_error.html
@@ -12,7 +12,7 @@
         <strong>Error:</strong> {{ msg }}
     </p>
     <p>
-        If you would to try your upload again,
+        If you would like to try your upload again,
         <a href="/docs/upload_csv.html">click here</a>.
     </p>
 </body>


### PR DESCRIPTION
We now require a password to upload a CSV file.  The acceptable passwords are specified by environment variable, separated by colons.  There is a default password only in DEV and STAGE environments.

This also fixes a typo in the error template.