### PR TITLE
Fix #80: introduce an optional minimum shift datetime

### DIFF
--- a/app/utils/formats.py
+++ b/app/utils/formats.py
@@ -284,7 +284,12 @@ class ATRecord:
         return cls._from_fields(key="row_id", core=core, custom=custom)
 
     @classmethod
-    def from_mobilize_shift(cls, data: Dict[str, str]) -> ATRecord:
+    def from_mobilize_shift(
+        cls, data: Dict[str, str], earliest: Optional[str] = None
+    ) -> Optional[ATRecord]:
+        if earliest and (shift_time := data.get("end")):
+            if parse(shift_time) < parse(earliest):
+                return None
         email = data["email"]
         if event_id := data.get("event id"):
             if timeslot_id := data.get("timeslot id"):

--- a/app/workers/csv_transfer.py
+++ b/app/workers/csv_transfer.py
@@ -93,6 +93,7 @@ def transfer_events(headings, rows):
 
 
 def transfer_shifts(headings, rows):
+    min_shift_datetime = os.getenv("MINIMUM_SHIFT_DATETIME")
     force_shift_updates = os.getenv("FORCE_SHIFT_UPDATES")
     MC.set("person")
     airtable_people = fetch_all_records(keys_only=True)
@@ -106,7 +107,9 @@ def transfer_shifts(headings, rows):
     for i, row in enumerate(rows):
         row_data = dict(zip(headings, row))
         MC.set("shift")
-        shift_record = ATRecord.from_mobilize_shift(row_data)
+        shift_record = ATRecord.from_mobilize_shift(row_data, min_shift_datetime)
+        if not shift_record:
+            continue
         event_id = shift_record.core_fields["event"]
         if airtable_events.get(event_id) is None:
             shift_record.core_fields["event"] = ""


### PR DESCRIPTION
We look for an environment variable `MINIMUM_SHIFT_DATETIME` which, if defined, should be a timezone-aware date-time specification.  If that variable is defined, then shifts whose end time is earlier than that minimum time are not transferred from Mobilize to Airtable.