### PR TITLE
Fix #80 again: terser yet more revealing logging

### DIFF
--- a/app/base/__init__.py
+++ b/app/base/__init__.py
@@ -19,4 +19,4 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
-from .general import Environment, env, lookup_env, log_error, prinl, Timestamp
+from .general import Environment, env, lookup_env, log_error, prinl, prinlv, Timestamp

--- a/app/base/general.py
+++ b/app/base/general.py
@@ -75,6 +75,15 @@ def prinl(*args, **kwargs):
     print(f"[{os.getpid()}]", *args, flush=True, **kwargs)
 
 
+def prinlv(*args, **kwargs):
+    """
+    Like `prinl` but for more verbose logging.
+    """
+    spec = os.getenv("VERBOSE_LOGGING", "")
+    if spec and spec != "0":
+        prinl(*args, **kwargs)
+
+
 def log_error(context: str) -> str:
     """Log a message about an exception, and return the message"""
     exc_type, exc_obj, exc_tb = sys.exc_info()

--- a/app/services/mobilize.py
+++ b/app/services/mobilize.py
@@ -29,7 +29,7 @@ from fastapi import File, UploadFile, Request, Form
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from ..base import prinl, log_error, env, Environment, Timestamp
+from ..base import prinl, prinlv, log_error, env, Environment, Timestamp
 from ..db import redis, ItemListStore as Store
 
 mobilize = APIRouter()
@@ -149,5 +149,5 @@ async def process_csv_rows(kind: str, headings: List, data: List[List]) -> bool:
         await Store.add_new_list("csv", list_key)
     except redis.Error:
         return False
-    prinl(f"Accepted Mobilize CSV file")
+    prinlv(f"Accepted Mobilize CSV file")
     return True

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -29,7 +29,7 @@ from typing import ClassVar, Dict, Optional, Any, List, Tuple
 import botocore.client
 import botocore.session
 
-from app.base import env, Environment, prinl
+from app.base import env, Environment, prinl, prinlv
 
 
 class MapContext:
@@ -98,7 +98,7 @@ class MapContext:
 
     @classmethod
     def load_config_from_aws(cls):
-        prinl("Loading form context from AWS...")
+        prinlv("Loading form context from AWS...")
         client, bucket, key = cls.get_client_and_target()
         response = client.get_object(Bucket=bucket, Key=key)
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
@@ -111,7 +111,7 @@ class MapContext:
 
     @classmethod
     def load_config_locally(cls, config_path: str):
-        prinl(f"Loading config from '{config_path}'...")
+        prinlv(f"Loading config from '{config_path}'...")
         with open(config_path, "r", encoding="utf-8") as fp:
             form_data = json.load(fp)
         cls.load_config_from_json_data(form_data)
@@ -138,15 +138,15 @@ class MapContext:
 
     @classmethod
     def save_config_locally(cls, config_path: str):
-        prinl(f"Saving config to '{config_path}'...")
+        prinlv(f"Saving config to '{config_path}'...")
         with open(config_path, "w", encoding="utf-8") as fp:
             json.dump(cls.save_config_to_json_data(), fp, indent=2)
             fp.write("\n")
-        prinl(f"Config saved.")
+        prinlv(f"Config saved.")
 
     @classmethod
     def put_config_to_aws(cls):
-        prinl(f"Saving config to AWS...")
+        prinlv(f"Saving config to AWS...")
         content = cls.save_config_to_json_data()
         body = (json.dumps(content, indent=2) + "\n").encode("utf-8")
         client, bucket, key = cls.get_client_and_target()
@@ -159,7 +159,7 @@ class MapContext:
         )
         if response["ResponseMetadata"]["HTTPStatusCode"] >= 400:
             raise RuntimeError(f"Failed to write config: {response}")
-        prinl(f"Config saved.")
+        prinlv(f"Config saved.")
 
     @classmethod
     def get(cls) -> str:

--- a/app/utils/formats.py
+++ b/app/utils/formats.py
@@ -31,7 +31,7 @@ from dateutil.tz import gettz
 from haleasy import HALEasy, LinkNotFoundError
 
 from .constants import MapContext as MC
-from ..base import prinl
+from ..base import prinlv
 
 
 class ANHash(HALEasy):
@@ -88,9 +88,6 @@ class ANHash(HALEasy):
 class ATRecord:
     key: str
     mod_date: datetime
-    # TODO: Fix the asymmetry in the naming of fields
-    # - core fields have their *source* name
-    # - custom fields have their *target* name
     core_fields: Dict[str, Any]
     custom_fields: Dict[str, Any]
     record_id: Optional[str] = ""
@@ -104,12 +101,12 @@ class ATRecord:
 
     @classmethod
     def dump_stats(cls, count: int, reset: bool = True):
-        prinl(f"Action Network core field counts for {count} people:")
+        prinlv(f"Action Network core field counts for {count} people:")
         for fn, fc in ATRecord.an_core_fields.items():
-            prinl(f"\t{fn}: {fc}")
-        prinl(f"Action Network custom field counts for {count} people:")
+            prinlv(f"\t{fn}: {fc}")
+        prinlv(f"Action Network custom field counts for {count} people:")
         for fn, fc in ATRecord.an_custom_fields.items():
-            prinl(f"\t{fn}: {fc}")
+            prinlv(f"\t{fn}: {fc}")
         if reset:
             cls.an_core_fields = {}
             cls.an_custom_fields = {}
@@ -127,10 +124,10 @@ class ATRecord:
         custom_fields = dict(record_data["fields"])
         core_field_map = MC.core_field_map()
         if not custom_fields.get(core_field_map[key]):
-            prinl(f"Airtable {MC.get()} record {record_id} has no {key} field.")
+            prinlv(f"Airtable {MC.get()} record {record_id} has no {key} field.")
             return None
         if not custom_fields.get(core_field_map["Timestamp (EST)"]):
-            prinl(f"Airtable {MC.get()} record {record_id} has no import timestamp.")
+            prinlv(f"Airtable {MC.get()} record {record_id} has no import timestamp.")
             custom_fields[core_field_map["Timestamp (EST)"]] = cls.epoch
         core_fields = {}
         for an_name, at_name in core_field_map.items():
@@ -201,7 +198,7 @@ class ATRecord:
         if amount == 0:
             return None
         if (currency := item["currency"]).lower() != "usd":
-            prinl(f"Donation {key} currency ({currency}) is unexpected.")
+            prinlv(f"Donation {key} currency ({currency}) is unexpected.")
         # find the recurrence
         if item["action_network:recurrence"]["recurring"]:
             period = item["action_network:recurrence"]["period"]
@@ -250,7 +247,7 @@ class ATRecord:
     def from_mobilize_event(cls, data: Dict[str, str]) -> Optional[ATRecord]:
         event_id = data.get("id")
         if not event_id:
-            prinl(f"Event data has no 'id' field.")
+            prinlv(f"Event data has no 'id' field.")
             return None
         slot_id = data.get("timeslot_id")
         if slot_id:
@@ -259,15 +256,15 @@ class ATRecord:
             row_id = f"Event {event_id}"
         deleted_at = data.get("deleted_at")
         if deleted_at:
-            prinl(f"Event {row_id} is a deleted event.")
+            prinlv(f"Event {row_id} is a deleted event.")
             return None
         timeslot_deleted_at = data.get("timeslot_deleted_at")
         if timeslot_deleted_at:
-            prinl(f"Timeslot {row_id} is a deleted timeslot.")
+            prinlv(f"Timeslot {row_id} is a deleted timeslot.")
             return None
         updated_at = data.get("updated_at")
         if not updated_at:
-            prinl(f"Event data has no 'updated_at' field.")
+            prinlv(f"Event data has no 'updated_at' field.")
             return None
         event_state = data.get("state") or data.get("organization_state")
         core: Dict[str, str] = {

--- a/app/workers/fetch_donations.py
+++ b/app/workers/fetch_donations.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Tuple, Set
 
 import requests
 
-from ..base import prinl, Environment, env
+from ..base import prinl, prinlv, Environment, env
 from ..utils import (
     MapContext as MC,
     ATRecord,
@@ -57,7 +57,7 @@ def fetch_donations() -> Tuple[Dict[str, List[ATRecord]], Set[str]]:
     constructing a map from donor URL to
     the donations made by that donor.
     """
-    prinl(f"Creating records for donations...")
+    prinlv(f"Creating records for donations...")
     MC.set("donation")
     session = requests.session()
     session.headers = MC.an_headers()
@@ -109,7 +109,7 @@ def fetch_donations() -> Tuple[Dict[str, List[ATRecord]], Set[str]]:
             if page_url:
                 page_urls.add(page_url)
             if (i + 1) % 10 == 0:
-                prinl(f"Processed {i + 1}/{len(donation_urls)}...")
+                prinlv(f"Processed {i + 1}/{len(donation_urls)}...")
     prinl(f"Created {donation_count} donation records for {len(donors)} donors.")
     return donors, page_urls
 
@@ -129,7 +129,7 @@ def fetch_donation_pages(page_urls: Set[str]) -> Dict[str, ATRecord]:
         page_record = ATRecord.from_donation_page(page_id, page_data)
         pages[page_record.key] = page_record
         if (i + 1) % 25 == 0:
-            prinl(f"Processed {i+1}/{len(page_urls)}...")
+            prinlv(f"Processed {i+1}/{len(page_urls)}...")
     prinl(f"Created {len(pages)} donation page records.")
     return pages
 
@@ -163,7 +163,7 @@ def fetch_donors(
             donation_record.core_fields["Email"] = [donor_record.key]
             donations[donation_record.key] = donation_record
         if (i + 1) % 25 == 0:
-            prinl(f"Processed {i+1}/{len(donor_map)}...")
+            prinlv(f"Processed {i+1}/{len(donor_map)}...")
     prinl(f"Created {len(donors)} donor records.")
     if env() is Environment.DEV:
         ATRecord.dump_stats(len(donors))

--- a/app/workers/fetch_people.py
+++ b/app/workers/fetch_people.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Set, Sequence
 
 import requests
 
-from ..base import prinl, Environment, env
+from ..base import prinl, prinlv, Environment, env
 from ..utils import (
     MapContext as MC,
     ATRecord,
@@ -75,7 +75,7 @@ def fetch_submitter_urls(form_name: str) -> Set[str]:
                 continue
             submitter_urls.add(submitter_url)
             if (i + 1) % 10 == 0:
-                prinl(f"Processed {i + 1}/{len(urls)}...")
+                prinlv(f"Processed {i + 1}/{len(urls)}...")
     prinl(f"Found {len(submitter_urls)} submitter(s).")
     return submitter_urls
 
@@ -127,7 +127,7 @@ def fetch_people(people_urls: Sequence[str]) -> Dict[str, ATRecord]:
         record = ATRecord.from_person(submitter_data)
         people[record.key] = record
         if (i + 1) % 25 == 0:
-            prinl(f"Processed {i+1}/{len(people_urls)}...")
+            prinlv(f"Processed {i+1}/{len(people_urls)}...")
     prinl(f"Created {len(people)} records for people.")
     if env() is Environment.DEV:
         ATRecord.dump_stats(len(people))

--- a/worker_runner.py
+++ b/worker_runner.py
@@ -22,7 +22,6 @@
 import asyncio
 import sys
 
-from app.base import prinl
 from app.workers.main import app
 
 if __name__ == "__main__":


### PR DESCRIPTION
We now log that we are trimming shifts by date.

This also makes a lot of improvements in logging that have been waiting for a while:

- introduce a VERBOSE_LOGGING environment variable to control the amount of logging.
- make all logging other than errors, updates, and top-level control flow be verbose.

This should reduce the Papertrail usage quite a bit.